### PR TITLE
ログイン画面の紹介コピーをアプリ機能説明に変更

### DIFF
--- a/src/components/Auth.test.tsx
+++ b/src/components/Auth.test.tsx
@@ -16,8 +16,11 @@ test('login form uses shared layout and password toggle', () => {
 
   expect(screen.getByText('Baseball Speedgun')).toBeInTheDocument();
   expect(
-    screen.getByText('一貫したUIで、記録から振り返りまでシームレスに')
+    screen.getByText('球速を記録して、選手別ランキングで振り返ろう')
   ).toBeInTheDocument();
+  expect(screen.getByText('記録を追加')).toBeInTheDocument();
+  expect(screen.getByText('ランキング')).toBeInTheDocument();
+  expect(screen.getByText('推移グラフ')).toBeInTheDocument();
 
   const passwordInput = screen.getByLabelText('パスワード');
   expect(passwordInput).toHaveAttribute('type', 'password');
@@ -39,6 +42,9 @@ test('signup form shares promo copy and hint text', () => {
   expect(screen.getByRole('heading', { name: '新規登録' })).toHaveClass(
     'auth-title'
   );
+  expect(
+    screen.getByText('球速を記録して、選手別ランキングで振り返ろう')
+  ).toBeInTheDocument();
   expect(
     screen.getByText('6文字以上のパスワードを設定してください')
   ).toBeInTheDocument();

--- a/src/components/AuthLayout.tsx
+++ b/src/components/AuthLayout.tsx
@@ -22,20 +22,20 @@ const AuthLayout: React.FC<AuthLayoutProps> = ({
           <section className="auth-copy card" aria-label="サービス紹介">
             <p className="eyebrow">Baseball Speedgun</p>
             <h1 className="auth-hero-title">
-              一貫したUIで、記録から振り返りまでシームレスに
+              球速を記録して、選手別ランキングで振り返ろう
             </h1>
             <p className="auth-copy-text">
-              ランキングや詳細画面と同じトーンで統一した認証体験。クラウドに保存された球速データへ安心してアクセスできます。
+              投球速度を日付付きで記録し、選手ごとの最高球速ランキングと推移グラフを自動で作成します。練習の成果を残して、次の目標につなげましょう。
             </p>
             <ul className="auth-value-list">
               <li>
-                <strong>統計の見える化</strong> 最高/平均を自動で整理
+                <strong>記録を追加</strong> 選手名・球速・日付をかんたん入力
               </li>
               <li>
-                <strong>どこでも更新</strong> モバイルでも入力しやすい共通フォーム
+                <strong>ランキング</strong> 最高球速で自動並び替え
               </li>
               <li>
-                <strong>安心のフィードバック</strong> 状態とエラーを明確に表示
+                <strong>推移グラフ</strong> 日々の変化とピークをひと目で確認
               </li>
             </ul>
           </section>


### PR DESCRIPTION
ログイン/新規登録画面の左側コピーがUI仕様の説明になっていたため、アプリでできること（記録/ランキング/推移）を伝える内容に変更しました。

- 追加/更新: src/components/AuthLayout.tsx
- テスト更新（TDD）: src/components/Auth.test.tsx

確認:
- `npm test -- --watchAll=false`
